### PR TITLE
Make log file output yields table a bit more readable

### DIFF
--- a/wums/output_tools.py
+++ b/wums/output_tools.py
@@ -190,7 +190,7 @@ def write_logfile(
                 # String conversion needed for non-primitive types (e.g., complex number)
                 logf.write(json.dumps(v, default=encode_complex, indent=5).replace("\\n", "\n"))
             else:
-                logf.write(f"{k}: {v}\n")
+                logf.write(f"{k}:\n{v}\n")
 
 
 def write_indexfile(outpath, template_dir="Templates", indexname="index.php"):


### PR DESCRIPTION
This is a trivial change but it makes the spacing of the yields summary table in the log files a bit more readable. I found it confusing before since the columns titles don't align with the info.

Before: https://kelong.web.cern.ch/WMassAnalysis/LowPU2026/2026Jul/etal_mumu.log

After: https://kelong.web.cern.ch/kelong/WMassAnalysis/LowPU2026/2026Jul/W/eta_mu.log