### PR TITLE
setAxisFlow: pass through category axes

### DIFF
--- a/wums/boostHistHelpers.py
+++ b/wums/boostHistHelpers.py
@@ -525,6 +525,10 @@ def enableAxisFlow(ax):
 
 def setAxisFlow(ax, under=None, over=None):
     # over/under modifies the overflow or underflow, 'None' to leave it unchanged
+    if isinstance(ax, (hist.axis.StrCategory, hist.axis.IntCategory)):
+        # category axes have no conventional under/overflow to toggle, and their
+        # constructor takes neither 'underflow' nor 'circular' -> leave unchanged
+        return ax
     if isinstance(ax, hist.axis.Integer):
         args = [ax.edges[0], ax.edges[-1]]
     elif isinstance(ax, hist.axis.Regular):


### PR DESCRIPTION
## What

`setAxisFlow` rebuilds each axis passing `underflow=`/`circular=`, but `StrCategory`/`IntCategory` accept neither. So `disableFlow`/`enableFlow` raise `TypeError` on any histogram that has a category axis with flow.

## Fix

Return category axes unchanged — they have no conventional under/overflow to toggle.

## Repro

```python
import hist
from wums import boostHistHelpers as hh
h = hist.Hist(
    hist.axis.Regular(3, 0, 3, name="qT"),
    hist.axis.StrCategory(["a", "b"], name="vars"),
    storage=hist.storage.Weight(),
)
hh.disableFlow(h)   # TypeError before this PR; works after
```

Surfaced in WRemnants `make_theory_corr` when a correction carries a `vars` category axis (see WMass/WRemnants#710).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
